### PR TITLE
Bypass validation if clearing number is specified ERP-1075

### DIFF
--- a/src/validators/SwedishBbanValidation.ts
+++ b/src/validators/SwedishBbanValidation.ts
@@ -80,6 +80,18 @@ export class SwedishBbanValidation implements IStrictValidation {
 
     validate(input: ValidationInput): ValidationResult {
         input = standarizeInput(input, 'none')
+
+        // Bypass validation if clearing number is specified. This is because the rules
+        // with all its edge cases was hard to implement. This exception should be reviewed
+        // and removed at a later stage when we get control of all the edge cases.
+        // Currently 5 digit clearing numbers is not supported
+        if (input.clearingNumber){
+            return {
+                valid: true,
+                reason: null
+            }
+        }
+
         const account = parseClearingAndAccountNumber(input.clearingNumber || null, input.accountNumber)
 
         const validSyntax = this._syntaxTester.test(account.bban)

--- a/test/SE/testBbanValidation.ts
+++ b/test/SE/testBbanValidation.ts
@@ -142,24 +142,31 @@ describe('SwedishBbanValidation', ()=> {
             })
         })
 
-        it('should invalidate an invalid Swedish BBAN account', ()=>{
+        xit('should invalidate an invalid Swedish BBAN account', ()=>{
             chai.expect(validation.validate({clearingNumber:'5440', accountNumber: '1122004'})).to.deep.equal({
                 'valid': false,
                 reason: "Invalid Swedish bban"
             })
         })
 
-        it('should invalidate an unknown clearing number in a Swedish BBAN account (type 0.0)', ()=>{
+        xit('should invalidate an unknown clearing number in a Swedish BBAN account (type 0.0)', ()=>{
             chai.expect(validation.validate({clearingNumber:'9030', accountNumber: '7777777'})).to.deep.equal({
                 valid: false,
                 reason: "Invalid Swedish bban"
             })
         })
 
-        it('should invalidate a Swedish BBAN account with invalid syntax', ()=>{
+        xit('should invalidate a Swedish BBAN account with invalid syntax', ()=>{
             chai.expect(validation.validate({clearingNumber:'5440', accountNumber: '88888888'})).to.deep.equal({
                 valid: false,
                 reason: 'Invalid swedish syntax. Number must be 11, 13 or 14 digits long (incl clearing number)'
+            })
+        })
+
+        it('should not validate a Swedish BBAN account if clearing number is specified', ()=>{
+            chai.expect(validation.validate({clearingNumber:'yoMan', accountNumber: '88888888'})).to.deep.equal({
+                valid: true,
+                reason: null
             })
         })
     })


### PR DESCRIPTION
Bypass validation if clearing number is specified, becauses swedbanks 5 digit clearing number is not supported in the current algorithm